### PR TITLE
Setting connection pool size for target and job repo DB

### DIFF
--- a/src/main/java/uk/ac/kcl/batch/BatchConfigurer.java
+++ b/src/main/java/uk/ac/kcl/batch/BatchConfigurer.java
@@ -67,6 +67,10 @@ public class BatchConfigurer extends DefaultBatchConfigurer {
         mainDatasource.setPassword(env.getProperty("jobRepository.password"));
         mainDatasource.setIdleTimeout(Long.valueOf(env.getProperty("jobRepository.idleTimeout")));
         mainDatasource.setMaxLifetime(Long.valueOf(env.getProperty("jobRepository.maxLifetime")));
+
+        if (env.getProperty("jobRepository.poolSize") != null) {
+            mainDatasource.setMaximumPoolSize(Integer.valueOf(env.getProperty("jobRepository.poolSize")));
+        }
         //mainDatasource.setAutoCommit(false);
         return mainDatasource;
     }

--- a/src/main/java/uk/ac/kcl/batch/JobConfiguration.java
+++ b/src/main/java/uk/ac/kcl/batch/JobConfiguration.java
@@ -227,6 +227,8 @@ public class JobConfiguration {
     private Long targetIdleTimeout;
     @Value("${target.maxLifetime}")
     private Long targetMaxLifeTime;
+    @Value("${target.poolSize}")
+    private Integer targetPoolSize;
 
     @Bean(destroyMethod = "close")
 //    @Primary
@@ -240,6 +242,9 @@ public class JobConfiguration {
         mainDatasource.setPassword(targetPassword);
         mainDatasource.setIdleTimeout(targetIdleTimeout);
         mainDatasource.setMaxLifetime(targetMaxLifeTime);
+        if (targetPoolSize > 0){
+            mainDatasource.setMaximumPoolSize(targetPoolSize);
+        }
         return mainDatasource;
     }
 

--- a/src/main/java/uk/ac/kcl/batch/JobConfiguration.java
+++ b/src/main/java/uk/ac/kcl/batch/JobConfiguration.java
@@ -182,7 +182,7 @@ public class JobConfiguration {
     private Long sourceMaxLifeTime;
     @Value("${source.leakDetectionThreshold}")
     private Long sourceLeakDetection;
-    @Value("${source.poolSize}")
+    @Value("${source.poolSize:10}")
     private Integer sourcePoolSize;
 
 
@@ -227,7 +227,7 @@ public class JobConfiguration {
     private Long targetIdleTimeout;
     @Value("${target.maxLifetime}")
     private Long targetMaxLifeTime;
-    @Value("${target.poolSize}")
+    @Value("${target.poolSize:10}")
     private Integer targetPoolSize;
 
     @Bean(destroyMethod = "close")


### PR DESCRIPTION
Introduced properties `target.poolSize` and `jobRepository.poolSize` to specify the size of the connection pool for target / job repository DBs. Works on the same basis as the already existing property `source.poolSize`.