### PR TITLE
fixing nullptr exceptions when processing documents with Tika and GATE

### DIFF
--- a/src/main/java/uk/ac/kcl/itemProcessors/TikaDocumentItemProcessor.java
+++ b/src/main/java/uk/ac/kcl/itemProcessors/TikaDocumentItemProcessor.java
@@ -103,6 +103,13 @@ public class TikaDocumentItemProcessor extends TLItemProcessor implements ItemPr
 
     @Override
     public Document process(final Document doc) throws Exception {
+
+        if (doc.getBinaryContent() == null) {
+            LOG.debug("{};No-binary-document",
+                    this.getClass().getSimpleName());
+            return doc;
+        }
+
         LOG.debug("starting " + this.getClass().getSimpleName() +" on doc " +doc.getDocName());
         long startTime = System.currentTimeMillis();
         ContentHandler handler;


### PR DESCRIPTION
Code changes:
- nullptr check when processing documents using Tika -- non existing binary content field to process
- nullptr check when trying to run GATE application on a document field that does not exist -- either empty content from the input DB record or the field has not been supplied by the previous item processor (e.g. Tika)
- changed verbosity of few log messages from INFO to DEBUG level (helpful when debugging, yet not very informative for end-user)