### PR TITLE
Refactor java11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk11
 sudo: required
 
 services:
@@ -29,7 +29,6 @@ cache:
     - $HOME/.gradle/wrapper/
 
 before_install:
-  - docker --version
   - mkdir -p "$HOME/bin";
   - export PATH="$HOME/bin:$PATH";
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > "$HOME/bin/docker-compose";
@@ -39,7 +38,11 @@ before_install:
   - sudo service postgresql stop
   # wait for postgresql to shutdown
   - while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
+  # print versions of used applications
+  - docker --version
   - sudo $HOME/bin/docker-compose --version
+  - tesseract --version
+  - convert --version
   - ./gradlew downloadDependencies > /dev/null
 
 script:

--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ dependencies {
 
 	// tika parsers dependencies
 	compile group: 'org.apache.pdfbox', name: 'jbig2-imageio', version: '3.0.2'
-    compile group: 'com.github.jai-imageio', name: 'jai-imageio-jpeg2000', version: '1.3.0'
+       compile group: 'com.github.jai-imageio', name: 'jai-imageio-jpeg2000', version: '1.3.0'
 	compile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.25.2'
 
 	compile group: 'org.apache.ws.commons.util', name: 'ws-commons-util', version: '1.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ repositories {
 }
 
 version '1.2.0'
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 sourceSets {
 	main {
@@ -131,10 +131,6 @@ dependencies {
     compile group: 'com.github.jai-imageio', name: 'jai-imageio-jpeg2000', version: '1.3.0'
 	compile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.25.2'
 
-
-	// temporary transitive dependencies fix
-	compile group: 'org.json', name: 'json', version: '20171018'
-
 	compile group: 'org.apache.ws.commons.util', name: 'ws-commons-util', version: '1.0.2'
 
 
@@ -144,6 +140,8 @@ dependencies {
 	testCompile group: 'org.mockito', name: 'mockito-core', version: '2.23.0'
 	testCompile group: 'de.sven-jacobs', name: 'loremipsum', version: '1.0'
 
+	// temporary dependencies for JUnit
+	compile group: 'org.json', name: 'json', version: '20171018'
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
Updated CogStack to be build and run using Java 11. Updated both gradle build and travis script.
As a side note, while building using travis added displaying the versions of tesseract and imagemagick (`convert`).