### PR TITLE
Refactor build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,88 @@
-FROM java:8
-MAINTAINER amos.folarin@kcl.ac.uk
-RUN apt-get update && apt-get install -y imagemagick --fix-missing  tesseract-ocr
+################################
+#
+# Java builder -- JDK
+#
+FROM openjdk:11-jdk-slim AS java-builder
 
-RUN mkdir -p /usr/src/
+# tesseract-ocr < 4.0 is only available from the previous Debian Stretch distribution
+RUN echo "deb http://ftp.de.debian.org/debian stretch main" >> /etc/apt/sources.list
+
+RUN apt-get update && \
+#	apt-get dist-upgrade -y && \
+#	apt-get install -y tesseract-ocr && \
+	apt-get install -y tesseract-ocr-osd=3.04.00-1 tesseract-ocr-eng=3.04.00-1 tesseract-ocr=3.04.01-5 && \
+	apt-get install -y imagemagick --fix-missing && \
+	apt-get clean autoclean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+
+
+################################
+#
+# Java runner -- JRE
+#
+FROM openjdk:11-jre-slim AS java-runner
+
+# tesseract-ocr < 4.0 is only available from the previous Debian Stretch distribution
+RUN echo "deb http://ftp.de.debian.org/debian stretch main" >> /etc/apt/sources.list
+
+RUN apt-get update && \
+#	apt-get dist-upgrade -y && \
+#	apt-get install -y tesseract-ocr && \
+	apt-get install -y tesseract-ocr-osd=3.04.00-1 tesseract-ocr-eng=3.04.00-1 tesseract-ocr=3.04.01-5 && \
+	apt-get install -y imagemagick --fix-missing && \
+	apt-get clean autoclean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+
+
+################################
+#
+# CogStack builder
+#
+FROM java-builder AS cogstack-builder
+
+# setup the build environment
+RUN mkdir -p /devel
+WORKDIR /devel
+
+COPY ./gradle/wrapper /devel/gradle/wrapper
+COPY ./gradlew /devel/
+
+RUN ./gradlew --version
+
+COPY ./build.gradle ./settings.gradle /devel/
+COPY . /devel/
+
+
+# build cogstack
+RUN ./gradlew bootJar --no-daemon
+
+
+
+################################
+#
+# CogStack runner
+#
+FROM java-runner
+
+# setup env
+#RUN apt-get update && apt-get install -y procps
+RUN mkdir -p /usr/src
 WORKDIR /usr/src/
 
 
+# copy artifacts
+RUN mkdir -p /usr/src/build/libs/
+COPY --from=cogstack-builder /devel/build/libs/cogstack-*.jar /usr/src/build/libs/
 
-COPY ./gradle/wrapper /usr/src/gradle/wrapper
-COPY ./gradlew /usr/src/
-RUN ./gradlew --version
-
-COPY ./build.gradle ./settings.gradle /usr/src/
-
-
-COPY . /usr/src
-
-RUN ./gradlew build
+RUN mkdir -p /usr/src/docker-cogstack/cogstack/
+COPY --from=cogstack-builder /devel/docker-cogstack/cogstack/ /usr/src/docker-cogstack/cogstack/
+COPY --from=cogstack-builder /devel/docker-cogstack/cogstack/*.sh /usr/src/
 
 
-
-COPY ./docker-cogstack/cogstack/ /usr/src/
-
-ENV LOG_LEVEL info
-ENV FILE_LOG_LEVEL off
-ENV LOG_FILE_NAME log
-
-
+# entry point
+#CMD ./test2.sh /cogstack/cogstack-*.jar /cogstack/cogstack_conf
 CMD ./test2.sh /usr/src/build/libs/cogstack-*.jar /usr/src/docker-cogstack/cogstack/cogstack_conf
-#CMD ./test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,19 +70,16 @@ FROM java-runner
 
 # setup env
 #RUN apt-get update && apt-get install -y procps
-RUN mkdir -p /usr/src
-WORKDIR /usr/src/
+RUN mkdir -p /cogstack
+WORKDIR /cogstack
 
 
 # copy artifacts
-RUN mkdir -p /usr/src/build/libs/
-COPY --from=cogstack-builder /devel/build/libs/cogstack-*.jar /usr/src/build/libs/
+COPY --from=cogstack-builder /devel/build/libs/cogstack-*.jar ./
 
-RUN mkdir -p /usr/src/docker-cogstack/cogstack/
-COPY --from=cogstack-builder /devel/docker-cogstack/cogstack/ /usr/src/docker-cogstack/cogstack/
-COPY --from=cogstack-builder /devel/docker-cogstack/cogstack/*.sh /usr/src/
+COPY --from=cogstack-builder /devel/docker-cogstack/cogstack/ ./
+COPY --from=cogstack-builder /devel/docker-cogstack/cogstack/*.sh ./
 
 
 # entry point
-#CMD ./test2.sh /cogstack/cogstack-*.jar /cogstack/cogstack_conf
-CMD ./test2.sh /usr/src/build/libs/cogstack-*.jar /usr/src/docker-cogstack/cogstack/cogstack_conf
+CMD ./test2.sh /cogstack/cogstack-*.jar /cogstack/cogstack_conf

--- a/docker-cogstack/java/Dockerfile
+++ b/docker-cogstack/java/Dockerfile
@@ -1,8 +1,0 @@
-FROM openjdk:8-slim
-
-RUN apt-get update && \
-	apt-get dist-upgrade -y && \
-	apt-get install -y imagemagick --fix-missing  tesseract-ocr && \
-	apt-get clean autoclean && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*

--- a/docker-cogstack/java/Dockerfile.devel
+++ b/docker-cogstack/java/Dockerfile.devel
@@ -1,0 +1,13 @@
+FROM openjdk:11-jdk-slim
+
+# tesseract-ocr < 4.0 is only available from the previous Debian Stretch distribution
+RUN echo "deb http://ftp.de.debian.org/debian stretch main" >> /etc/apt/sources.list
+
+RUN apt-get update && \
+#	apt-get dist-upgrade -y && \
+#	apt-get install -y tesseract-ocr && \
+	apt-get install -y tesseract-ocr-osd=3.04.00-1 tesseract-ocr-eng=3.04.00-1 tesseract-ocr=3.04.01-5 && \
+	apt-get install -y imagemagick --fix-missing && \
+	apt-get clean autoclean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*

--- a/docker-cogstack/java/Dockerfile.run
+++ b/docker-cogstack/java/Dockerfile.run
@@ -1,0 +1,13 @@
+FROM openjdk:11-jre-slim
+
+# tesseract-ocr < 4.0 is only available from the previous Debian Stretch distribution
+RUN echo "deb http://ftp.de.debian.org/debian stretch main" >> /etc/apt/sources.list
+
+RUN apt-get update && \
+#	apt-get dist-upgrade -y && \
+#	apt-get install -y tesseract-ocr && \
+	apt-get install -y tesseract-ocr-osd=3.04.00-1 tesseract-ocr-eng=3.04.00-1 tesseract-ocr=3.04.01-5 && \
+	apt-get install -y imagemagick --fix-missing && \
+	apt-get clean autoclean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*

--- a/localBuild/Dockerfile.devel
+++ b/localBuild/Dockerfile.devel
@@ -1,6 +1,6 @@
 ARG VERSION
 
-FROM cogstacksystems/cogstack-java-run:${VERSION}
+FROM cogstacksystems/cogstack-java-devel:${VERSION}
 
 # setup the build environment
 #
@@ -17,6 +17,6 @@ COPY . /devel/
 
 
 # build cogstack
-RUN ./gradlew bootRepackage
+RUN ./gradlew bootJar --no-daemon
 
 #CMD ./gradlew bootRepackage

--- a/localBuild/Dockerfile.run
+++ b/localBuild/Dockerfile.run
@@ -2,8 +2,13 @@ ARG VERSION
 
 FROM cogstacksystems/cogstack-java-run:${VERSION}
 
+
 # setup env
 #
+# DEBUG:
+#RUN apt-get update && apt-get install -y procps
+#
+
 RUN mkdir -p /usr/src
 WORKDIR /usr/src/
 

--- a/localBuild/build-containers.sh
+++ b/localBuild/build-containers.sh
@@ -4,8 +4,13 @@ set -e
 VERSION_TAG=local
 
 echo "--------------------------------"
+echo "building image: cogstacksystems/cogstack-java-devel:$VERSION_TAG"
+( cd ../docker-cogstack/java ; docker build -t cogstacksystems/cogstack-java-devel:$VERSION_TAG -f Dockerfile.devel . )
+echo ""
+
+echo "--------------------------------"
 echo "building image: cogstacksystems/cogstack-java-run:$VERSION_TAG"
-( cd ../docker-cogstack/java ; docker build -t cogstacksystems/cogstack-java-run:$VERSION_TAG . )
+( cd ../docker-cogstack/java ; docker build -t cogstacksystems/cogstack-java-run:$VERSION_TAG -f Dockerfile.run . )
 echo ""
 
 echo "--------------------------------"


### PR DESCRIPTION
Modified the way the current CogStack image is build in DockerHub with some cleanups. The image is now build using multi stage builds. As a base image, OpenJDK 11 is being used (-JDK: builder, -JRE: runner), which is based on Debian slim.

The final image with CogStack Pipeline now contains only the JAR file with a sample config file, greatly reducing the size: from 1.4 GB to 650 MB.

The `localBuild` directory with some of the resources under `docker-cogstack` dir will be moved to a different directory during the repo cleanup.