### PR TITLE
set "localParitioning" scheme to be the default one when not set

### DIFF
--- a/src/main/groovy/uk/ac/kcl/model/Document.groovy
+++ b/src/main/groovy/uk/ac/kcl/model/Document.groovy
@@ -11,6 +11,8 @@ import java.sql.Timestamp
 class Document {
 
     //generic fields
+    // deprecated
+    // TODO: remove in future
     //String databaseName
     //String databaseSchema
 

--- a/src/main/groovy/uk/ac/kcl/model/Document.groovy
+++ b/src/main/groovy/uk/ac/kcl/model/Document.groovy
@@ -11,13 +11,19 @@ import java.sql.Timestamp
 class Document {
 
     //generic fields
-    String databaseName
-    String databaseSchema
+    //String databaseName
+    //String databaseSchema
+
+    // used when processing documents from metadata tables within docman profile
     String srcTableName
     String srcColumnFieldName
     String primaryKeyFieldName
+
+    // universal fields
     String primaryKeyFieldValue
     Timestamp timeStamp
+
+    // auxiliary members
     HashSet<RuntimeException> exceptions = new HashSet<>()
     Gson gson = new GsonBuilder().create();
 
@@ -36,8 +42,13 @@ class Document {
     //for es
     HashMap<String,Object> associativeArray = new HashMap<String,Object>();
 
-    public String getDocName(){
-        return srcTableName+"_"+srcColumnFieldName+"_"+primaryKeyFieldValue
+    String getDocName(){
+        String name = ""
+        if (srcTableName != null && srcTableName.length() > 0)
+            name += srcTableName + "_"
+        if (srcColumnFieldName != null && srcColumnFieldName.length() > 0)
+            name += srcColumnFieldName + "_"
+        return name + primaryKeyFieldValue
     }
 
 }

--- a/src/main/java/uk/ac/kcl/Main.java
+++ b/src/main/java/uk/ac/kcl/Main.java
@@ -45,7 +45,7 @@ public class Main {
         for (File listOfFile : listOfFiles) {
             if (listOfFile.isFile()) {
                 if (listOfFile.getName().endsWith(".properties")) {
-                    LOG.info("Properties sile found:" + listOfFile.getName() +
+                    LOG.info("Properties file found:" + listOfFile.getName() +
                             ". Attempting to launch application context");
                     Properties properties = new Properties();
                     InputStream input;

--- a/src/main/java/uk/ac/kcl/rowmappers/DocumentRowMapper.java
+++ b/src/main/java/uk/ac/kcl/rowmappers/DocumentRowMapper.java
@@ -53,16 +53,18 @@ public class DocumentRowMapper implements RowMapper<Document>{
     ApplicationContext context;
 
     // mandatory properties required to perform record mapping
-    @Value("${source.srcTableName}")
-    private String srcTableName;
-    @Value("${source.srcColumnFieldName}")
-    private String srcColumnFieldName;
-    @Value("${source.primaryKeyFieldName}")
-    private String primaryKeyFieldName;
     @Value("${source.primaryKeyFieldValue}")
     private String primaryKeyFieldValue;
     @Value("${source.timeStamp}")
     private String timeStamp;
+
+    // optional fields, required in docman profile
+    @Value("${source.srcTableName:#{null}}")
+    private String srcTableName;
+    @Value("${source.srcColumnFieldName:#{null}}")
+    private String srcColumnFieldName;
+    @Value("${source.primaryKeyFieldName:#{null}}")
+    private String primaryKeyFieldName;
 
     // profile-specific properties used when performing mapping
     @Value("${reindexColumn:#{null}}")

--- a/src/main/java/uk/ac/kcl/rowmappers/DocumentRowMapper.java
+++ b/src/main/java/uk/ac/kcl/rowmappers/DocumentRowMapper.java
@@ -159,9 +159,12 @@ public class DocumentRowMapper implements RowMapper<Document>{
     }
 
     private void mapDBMetadata(Document doc, ResultSet rs) throws SQLException {
-        doc.setSrcTableName(rs.getString(srcTableName));
-        doc.setSrcColumnFieldName(rs.getString(srcColumnFieldName));
-        doc.setPrimaryKeyFieldName(rs.getString(primaryKeyFieldName));
+        if (Arrays.asList(this.env.getActiveProfiles()).contains("docman")) {
+            // these fields are only used when reading documents from metadata tables using docman profile
+            doc.setSrcTableName(rs.getString(srcTableName));
+            doc.setSrcColumnFieldName(rs.getString(srcColumnFieldName));
+            doc.setPrimaryKeyFieldName(rs.getString(primaryKeyFieldName));
+        }
         doc.setPrimaryKeyFieldValue(rs.getString(primaryKeyFieldValue));
         doc.setTimeStamp(rs.getTimestamp(timeStamp));
     }


### PR DESCRIPTION
Minor changes, mostly for ease of use when defining job configuration:
- set `localParitioning` profile to be active by default one when not set.
- minor polishing of printing exception stack trace in Main.
In any case, we are also planning to deprecate the master-slave mode which uses `remotePartitioning`, hence the `localPartitioning` should be the default one.