### PR TITLE
Added support for multiple ES nodes for ESRestService

### DIFF
--- a/src/main/java/uk/ac/kcl/service/ESRestService.java
+++ b/src/main/java/uk/ac/kcl/service/ESRestService.java
@@ -63,8 +63,8 @@ public class ESRestService {
     // optional properties
     //
     // additional ES nodes provided as a list 'address1:port1,address2:port2',...
-    @Value("${elasticsearch.cluster.extraNodes:#{null}}")
-    private String extraNodes;
+    @Value("${elasticsearch.cluster.slaveNodes:#{null}}")
+    private String slaveNodes;
 
     @Value("${elasticsearch.index.name:default_index")
     private String indexName;
@@ -200,8 +200,8 @@ public class ESRestService {
 
         // add the extra nodes if provided
         try {
-            if (extraNodes != null && extraNodes.length() > 0) {
-                String[] hosts = extraNodes.split(",");
+            if (slaveNodes != null && slaveNodes.length() > 0) {
+                String[] hosts = slaveNodes.split(",");
                 for (String h : hosts) {
                     // get the last index of ':' since the hosts can start with 'xxx://...'
                     int i = h.lastIndexOf(':');


### PR DESCRIPTION
Added support for using multiple ElasticSearch nodes when sending documents using ESRestService. For backwards compatibility, the master node is defined the old way, by combination of `elasticsearch.cluster.host` and `elasticsearch.cluster.port` properties.

The additional (slave) nodes can be provided in `elasticsearch.cluster.slaveNodes` property, where the hosts can be represented as a comma-separated collection of pairs `host` and `port`, such as: `localhost:9201, localhost:9202, elasticsearch2:9200`.

Closes also #46 .