### PR TITLE
Feat tesseract 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ env:
   OMP_THREAD_LIMIT: 1
 
 addons:
-  sources:
+  apt:
+    sources:
     # tesseract-ocr >= 4.0 is not available in the standard Xenial / Trusty distro
     - ppa:alex-p/tesseract-ocr
-  apt:
     packages:
       - tesseract-ocr
       - libtesseract-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
   apt:
     sources:
     # tesseract-ocr >= 4.0 is not available in the standard Xenial / Trusty distro
-    - ppa:alex-p/tesseract-ocr
+    - sourceline: 'ppa:alex-p/tesseract-ocr'
     packages:
       - tesseract-ocr
       - libtesseract-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 addons:
   sources:
     # tesseract-ocr >= 4.0 is not available in the standard Xenial / Trusty distro
-    - alex-p/tesseract-ocr
+    - ppa:alex-p/tesseract-ocr
   apt:
     packages:
       - tesseract-ocr

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+dist: xenial
+
 language: java
 jdk:
   - openjdk11
+
 sudo: required
 
 services:
@@ -8,8 +11,12 @@ services:
 
 env:
   DOCKER_COMPOSE_VERSION: 1.14.0
+  OMP_THREAD_LIMIT: 1
 
 addons:
+  sources:
+    # tesseract-ocr >= 4.0 is not available in the standard Xenial / Trusty distro
+    - alex-p/tesseract-ocr
   apt:
     packages:
       - tesseract-ocr

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 #	apt-get install -y tesseract-ocr && \
 	apt-get install -y tesseract-ocr=4.0.0-1+b1 tesseract-ocr-eng=1:4.00~git30-7274cfa-1 tesseract-ocr-osd=1:4.00~git30-7274cfa-1 && \
 ###	apt-get install -y tesseract-ocr-osd=3.04.00-1 tesseract-ocr-eng=3.04.00-1 tesseract-ocr=3.04.01-5 && \
-	apt-get install -y imagemagick --fix-missing && \
+	apt-get install -y imagemagick=8:6.9.10.14+dfsg-7 --fix-missing && \
 	apt-get clean autoclean && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
@@ -35,7 +35,7 @@ RUN apt-get update && \
 #	apt-get install -y tesseract-ocr && \
 	apt-get install -y tesseract-ocr=4.0.0-1+b1 tesseract-ocr-eng=1:4.00~git30-7274cfa-1 tesseract-ocr-osd=1:4.00~git30-7274cfa-1 && \
 ###	apt-get install -y tesseract-ocr-osd=3.04.00-1 tesseract-ocr-eng=3.04.00-1 tesseract-ocr=3.04.01-5 && \
-	apt-get install -y imagemagick --fix-missing && \
+	apt-get install -y imagemagick=8:6.9.10.14+dfsg-7 --fix-missing && \
 	apt-get clean autoclean && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,13 @@
 FROM openjdk:11-jdk-slim AS java-builder
 
 # tesseract-ocr < 4.0 is only available from the previous Debian Stretch distribution
-RUN echo "deb http://ftp.de.debian.org/debian stretch main" >> /etc/apt/sources.list
+# for installing it plese uncomment the following lines with '###''
+### RUN echo "deb http://ftp.de.debian.org/debian stretch main" >> /etc/apt/sources.list
 
 RUN apt-get update && \
 #	apt-get dist-upgrade -y && \
-#	apt-get install -y tesseract-ocr && \
-	apt-get install -y tesseract-ocr-osd=3.04.00-1 tesseract-ocr-eng=3.04.00-1 tesseract-ocr=3.04.01-5 && \
+	apt-get install -y tesseract-ocr && \
+###	apt-get install -y tesseract-ocr-osd=3.04.00-1 tesseract-ocr-eng=3.04.00-1 tesseract-ocr=3.04.01-5 && \
 	apt-get install -y imagemagick --fix-missing && \
 	apt-get clean autoclean && \
     apt-get autoremove -y && \
@@ -25,12 +26,13 @@ RUN apt-get update && \
 FROM openjdk:11-jre-slim AS java-runner
 
 # tesseract-ocr < 4.0 is only available from the previous Debian Stretch distribution
-RUN echo "deb http://ftp.de.debian.org/debian stretch main" >> /etc/apt/sources.list
+# for installing it plese uncomment the following lines with '###''
+### RUN echo "deb http://ftp.de.debian.org/debian stretch main" >> /etc/apt/sources.list
 
 RUN apt-get update && \
 #	apt-get dist-upgrade -y && \
-#	apt-get install -y tesseract-ocr && \
-	apt-get install -y tesseract-ocr-osd=3.04.00-1 tesseract-ocr-eng=3.04.00-1 tesseract-ocr=3.04.01-5 && \
+	apt-get install -y tesseract-ocr && \
+###	apt-get install -y tesseract-ocr-osd=3.04.00-1 tesseract-ocr-eng=3.04.00-1 tesseract-ocr=3.04.01-5 && \
 	apt-get install -y imagemagick --fix-missing && \
 	apt-get clean autoclean && \
     apt-get autoremove -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ FROM openjdk:11-jdk-slim AS java-builder
 
 RUN apt-get update && \
 #	apt-get dist-upgrade -y && \
-	apt-get install -y tesseract-ocr && \
+#	apt-get install -y tesseract-ocr && \
+	apt-get install -y tesseract-ocr=4.0.0-1+b1 tesseract-ocr-eng=1:4.00~git30-7274cfa-1 tesseract-ocr-osd=1:4.00~git30-7274cfa-1 && \
 ###	apt-get install -y tesseract-ocr-osd=3.04.00-1 tesseract-ocr-eng=3.04.00-1 tesseract-ocr=3.04.01-5 && \
 	apt-get install -y imagemagick --fix-missing && \
 	apt-get clean autoclean && \
@@ -31,7 +32,8 @@ FROM openjdk:11-jre-slim AS java-runner
 
 RUN apt-get update && \
 #	apt-get dist-upgrade -y && \
-	apt-get install -y tesseract-ocr && \
+#	apt-get install -y tesseract-ocr && \
+	apt-get install -y tesseract-ocr=4.0.0-1+b1 tesseract-ocr-eng=1:4.00~git30-7274cfa-1 tesseract-ocr-osd=1:4.00~git30-7274cfa-1 && \
 ###	apt-get install -y tesseract-ocr-osd=3.04.00-1 tesseract-ocr-eng=3.04.00-1 tesseract-ocr=3.04.01-5 && \
 	apt-get install -y imagemagick --fix-missing && \
 	apt-get clean autoclean && \

--- a/travis_gradle_build.sh
+++ b/travis_gradle_build.sh
@@ -6,7 +6,7 @@ export PING_SLEEP=30s
 export WORKDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export BUILD_OUTPUT=$WORKDIR/build.out
 
-DUMP_LINES=2000
+DUMP_LINES=500
 
 touch $BUILD_OUTPUT
 


### PR DESCRIPTION
Moving forward with the new version of tesseract. The changes include:
- CogStack Pipeline `Dockerfile` -- since the image is based on the OpenJDK v.11 (based on the newest debian), the new version will be downloaded automatically.
- TravisCI build configuration -- since travis builds can be only based either on Ubuntu Trusty or Xenial distros, needed to add a custom PPA repo to download the newest version of tesseract (Trusty / Xenial only can provide tesseract in 3.x version)

CogStack Pipeline already can use the new version of Tesseract since Tika dependencies have been updated to the newest version.