### PR TITLE
fix: increase timeout in integration tests

### DIFF
--- a/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithSchedulingAndConfiguredStartTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithSchedulingAndConfiguredStartTests.java
@@ -48,7 +48,7 @@ public class BasicConfigWithSchedulingAndConfiguredStartTests {
     public void basicConfigurerdStartPkPartitionWithSchedulingTest() {
         testUtils.insertFreshDataIntoBasicTableAfterDelay(env.getProperty("tblInputDocs"),15000,76,150,false);
         try {
-            Thread.sleep(10000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithSchedulingLargeInsertTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithSchedulingLargeInsertTests.java
@@ -44,7 +44,7 @@ public class BasicConfigWithSchedulingLargeInsertTests {
     public void basicTimestampPartitionWithSchedulingTest() {
         testUtils.insertFreshDataIntoBasicTableAfterDelay(env.getProperty("tblInputDocs"),15000,76,150,false);
         try {
-            Thread.sleep(10000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithSchedulingSmallInsertTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithSchedulingSmallInsertTests.java
@@ -44,7 +44,7 @@ public class BasicConfigWithSchedulingSmallInsertTests {
     public void basicTimestampPartitionWithSchedulingTest() {
         testUtils.insertFreshDataIntoBasicTableAfterDelay(env.getProperty("tblInputDocs"),15000,5,8,false);
         try {
-            Thread.sleep(10000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithoutSchedulingTests.java
@@ -47,7 +47,7 @@ public class BasicConfigWithoutSchedulingTests {
         jobLauncher.launchJob();
 
         try {
-            Thread.sleep(10000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/integration-test/java/uk/ac/kcl/testservices/BiolarkWebserviceWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/BiolarkWebserviceWithoutSchedulingTests.java
@@ -54,7 +54,7 @@ public class BiolarkWebserviceWithoutSchedulingTests {
     public void biolarkTest() {
         jobLauncher.launchJob();
         try {
-            Thread.sleep(10000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/integration-test/java/uk/ac/kcl/testservices/BioyodieWebserviceWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/BioyodieWebserviceWithoutSchedulingTests.java
@@ -51,7 +51,7 @@ public class BioyodieWebserviceWithoutSchedulingTests {
     public void bioyodieTest() {
         jobLauncher.launchJob();
         try {
-            Thread.sleep(10000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/integration-test/java/uk/ac/kcl/testservices/DeIdentificationWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/DeIdentificationWithoutSchedulingTests.java
@@ -54,7 +54,7 @@ public class DeIdentificationWithoutSchedulingTests {
 
         jobLauncher.launchJob();
         try {
-            Thread.sleep(10000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/integration-test/java/uk/ac/kcl/testservices/DocmanReaderWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/DocmanReaderWithoutSchedulingTests.java
@@ -61,7 +61,7 @@ public class DocmanReaderWithoutSchedulingTests {
     public void docmanReaderTest() {
         jobLauncher.launchJob();
         try {
-            Thread.sleep(10000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/integration-test/java/uk/ac/kcl/testservices/FullPipelineWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/FullPipelineWithoutSchedulingTests.java
@@ -53,7 +53,7 @@ public class FullPipelineWithoutSchedulingTests {
     public void fullPipelineTest() {
         jobLauncher.launchJob();
         try {
-            Thread.sleep(10000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/integration-test/java/uk/ac/kcl/testservices/GATEWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/GATEWithoutSchedulingTests.java
@@ -52,7 +52,7 @@ public class GATEWithoutSchedulingTests {
     public void gatePipelineTest() {
         jobLauncher.launchJob();
         try {
-            Thread.sleep(10000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/integration-test/java/uk/ac/kcl/testservices/JdbcMapWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/JdbcMapWithoutSchedulingTests.java
@@ -58,7 +58,7 @@ public class JdbcMapWithoutSchedulingTests {
         jobLauncher.launchJob();
 
         try {
-            Thread.sleep(10000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/integration-test/java/uk/ac/kcl/testservices/LineFixerWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/LineFixerWithoutSchedulingTests.java
@@ -52,7 +52,7 @@ public class LineFixerWithoutSchedulingTests {
     public void lineFixerTest() {
         jobLauncher.launchJob();
         try {
-            Thread.sleep(10000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/integration-test/java/uk/ac/kcl/testservices/PdfboxWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/PdfboxWithoutSchedulingTests.java
@@ -51,7 +51,7 @@ public class PdfboxWithoutSchedulingTests {
         jobLauncher.launchJob();
 
         try {
-            Thread.sleep(10000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/integration-test/java/uk/ac/kcl/testservices/ReindexWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/ReindexWithoutSchedulingTests.java
@@ -41,7 +41,7 @@ public class ReindexWithoutSchedulingTests {
     public void reindexTest() {
         jobLauncher.launchJob();
         try {
-            Thread.sleep(10000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/integration-test/java/uk/ac/kcl/testservices/TikaWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/TikaWithoutSchedulingTests.java
@@ -50,7 +50,7 @@ public class TikaWithoutSchedulingTests {
         jobLauncher.launchJob();
 
         try {
-            Thread.sleep(10000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Quick fix: increase the wait timeout for data sink to be ready when performing integration tests. Corresponds to PR #63 .