### PR TITLE
Refactor tests

### DIFF
--- a/examples/download_db_dumps.sh
+++ b/examples/download_db_dumps.sh
@@ -2,7 +2,7 @@
 set -e
 
 AWS_S3_BUCKET_URL="http://cogstack.s3.amazonaws.com"
-DATA_PATH="share/examples/db_dump_v2"
+DATA_PATH="share/examples/db_dump"
 DATA_PATH_URL="$AWS_S3_BUCKET_URL/$DATA_PATH"
 
 # download the db dumps for examples

--- a/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithSchedulingAndConfiguredStartTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithSchedulingAndConfiguredStartTests.java
@@ -48,8 +48,8 @@ public class BasicConfigWithSchedulingAndConfiguredStartTests {
     public void basicConfigurerdStartPkPartitionWithSchedulingTest() {
         testUtils.insertFreshDataIntoBasicTableAfterDelay(env.getProperty("tblInputDocs"),15000,76,150,false);
         try {
-            Thread.sleep(20000);
-        } catch (InterruptedException e) {
+            testUtils.waitForEsReady(30000);
+        } catch (RuntimeException e) {
             e.printStackTrace();
         }
         //note, in this test, we upsert documents, overriding existng ones. hence why ther ate 75 in the index and 150

--- a/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithSchedulingLargeInsertTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithSchedulingLargeInsertTests.java
@@ -44,8 +44,8 @@ public class BasicConfigWithSchedulingLargeInsertTests {
     public void basicTimestampPartitionWithSchedulingTest() {
         testUtils.insertFreshDataIntoBasicTableAfterDelay(env.getProperty("tblInputDocs"),15000,76,150,false);
         try {
-            Thread.sleep(20000);
-        } catch (InterruptedException e) {
+            testUtils.waitForEsReady(30000);
+        } catch (RuntimeException e) {
             e.printStackTrace();
         }
         //note, in this test, we upsert documents, overriding existng ones. hence why there are 75 in the index and 150

--- a/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithSchedulingSmallInsertTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithSchedulingSmallInsertTests.java
@@ -44,8 +44,8 @@ public class BasicConfigWithSchedulingSmallInsertTests {
     public void basicTimestampPartitionWithSchedulingTest() {
         testUtils.insertFreshDataIntoBasicTableAfterDelay(env.getProperty("tblInputDocs"),15000,5,8,false);
         try {
-            Thread.sleep(20000);
-        } catch (InterruptedException e) {
+            testUtils.waitForEsReady(30000);
+        } catch (RuntimeException e) {
             e.printStackTrace();
         }
         //note, in this test, we upsert documents, overriding existng ones. hence why there are 75 in the index and 150

--- a/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/BasicConfigWithoutSchedulingTests.java
@@ -47,8 +47,8 @@ public class BasicConfigWithoutSchedulingTests {
         jobLauncher.launchJob();
 
         try {
-            Thread.sleep(20000);
-        } catch (InterruptedException e) {
+           testUtils.waitForEsReady(30000);
+        } catch (RuntimeException e) {
             e.printStackTrace();
         }
         assertEquals(75,testUtils.countOutputDocsInES());

--- a/src/integration-test/java/uk/ac/kcl/testservices/BiolarkWebserviceWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/BiolarkWebserviceWithoutSchedulingTests.java
@@ -54,8 +54,8 @@ public class BiolarkWebserviceWithoutSchedulingTests {
     public void biolarkTest() {
         jobLauncher.launchJob();
         try {
-            Thread.sleep(20000);
-        } catch (InterruptedException e) {
+            testUtils.waitForEsReady(30000);
+        } catch (RuntimeException e) {
             e.printStackTrace();
         }
         assertEquals(75,testUtils.countOutputDocsInES());

--- a/src/integration-test/java/uk/ac/kcl/testservices/BioyodieWebserviceWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/BioyodieWebserviceWithoutSchedulingTests.java
@@ -51,8 +51,8 @@ public class BioyodieWebserviceWithoutSchedulingTests {
     public void bioyodieTest() {
         jobLauncher.launchJob();
         try {
-            Thread.sleep(20000);
-        } catch (InterruptedException e) {
+            testUtils.waitForEsReady(30000);
+        } catch (RuntimeException e) {
             e.printStackTrace();
         }
         assertEquals(75,testUtils.countOutputDocsInES());

--- a/src/integration-test/java/uk/ac/kcl/testservices/DeIdentificationWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/DeIdentificationWithoutSchedulingTests.java
@@ -54,8 +54,8 @@ public class DeIdentificationWithoutSchedulingTests {
 
         jobLauncher.launchJob();
         try {
-            Thread.sleep(20000);
-        } catch (InterruptedException e) {
+            testUtils.waitForEsReady(30000);
+        } catch (RuntimeException e) {
             e.printStackTrace();
         }
         assertEquals(106,testUtils.countOutputDocsInES());

--- a/src/integration-test/java/uk/ac/kcl/testservices/DocmanReaderWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/DocmanReaderWithoutSchedulingTests.java
@@ -61,8 +61,8 @@ public class DocmanReaderWithoutSchedulingTests {
     public void docmanReaderTest() {
         jobLauncher.launchJob();
         try {
-            Thread.sleep(20000);
-        } catch (InterruptedException e) {
+            testUtils.waitForEsReady(30000);
+        } catch (RuntimeException e) {
             e.printStackTrace();
         }
         assertEquals(2,testUtils.countOutputDocsInES());

--- a/src/integration-test/java/uk/ac/kcl/testservices/FullPipelineWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/FullPipelineWithoutSchedulingTests.java
@@ -53,8 +53,8 @@ public class FullPipelineWithoutSchedulingTests {
     public void fullPipelineTest() {
         jobLauncher.launchJob();
         try {
-            Thread.sleep(20000);
-        } catch (InterruptedException e) {
+            testUtils.waitForEsReady(30000);
+        } catch (RuntimeException e) {
             e.printStackTrace();
         }
         assertEquals(31,testUtils.countOutputDocsInES());

--- a/src/integration-test/java/uk/ac/kcl/testservices/GATEWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/GATEWithoutSchedulingTests.java
@@ -52,8 +52,8 @@ public class GATEWithoutSchedulingTests {
     public void gatePipelineTest() {
         jobLauncher.launchJob();
         try {
-            Thread.sleep(20000);
-        } catch (InterruptedException e) {
+            testUtils.waitForEsReady(30000);
+        } catch (RuntimeException e) {
             e.printStackTrace();
         }
         assertEquals(100,testUtils.countOutputDocsInES());

--- a/src/integration-test/java/uk/ac/kcl/testservices/JdbcMapWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/JdbcMapWithoutSchedulingTests.java
@@ -58,8 +58,8 @@ public class JdbcMapWithoutSchedulingTests {
         jobLauncher.launchJob();
 
         try {
-            Thread.sleep(20000);
-        } catch (InterruptedException e) {
+            testUtils.waitForEsReady(30000);
+        } catch (RuntimeException e) {
             e.printStackTrace();
         }
         Map<String, Object> row = dbmsTestUtils.getRowInOutputTable(1);

--- a/src/integration-test/java/uk/ac/kcl/testservices/LineFixerWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/LineFixerWithoutSchedulingTests.java
@@ -52,8 +52,8 @@ public class LineFixerWithoutSchedulingTests {
     public void lineFixerTest() {
         jobLauncher.launchJob();
         try {
-            Thread.sleep(20000);
-        } catch (InterruptedException e) {
+            testUtils.waitForEsReady(30000);
+        } catch (RuntimeException e) {
             e.printStackTrace();
         }
 

--- a/src/integration-test/java/uk/ac/kcl/testservices/PdfboxWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/PdfboxWithoutSchedulingTests.java
@@ -51,8 +51,8 @@ public class PdfboxWithoutSchedulingTests {
         jobLauncher.launchJob();
 
         try {
-            Thread.sleep(20000);
-        } catch (InterruptedException e) {
+            testUtils.waitForEsReady(30000);
+        } catch (RuntimeException e) {
             e.printStackTrace();
         }
         assertEquals(55, testUtils.countOutputDocsInES());

--- a/src/integration-test/java/uk/ac/kcl/testservices/ReindexWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/ReindexWithoutSchedulingTests.java
@@ -41,8 +41,8 @@ public class ReindexWithoutSchedulingTests {
     public void reindexTest() {
         jobLauncher.launchJob();
         try {
-            Thread.sleep(20000);
-        } catch (InterruptedException e) {
+            testUtils.waitForEsReady(30000);
+        } catch (RuntimeException e) {
             e.printStackTrace();
         }
         assertEquals(75,testUtils.countOutputDocsInES());

--- a/src/integration-test/java/uk/ac/kcl/testservices/TikaWithoutSchedulingTests.java
+++ b/src/integration-test/java/uk/ac/kcl/testservices/TikaWithoutSchedulingTests.java
@@ -50,8 +50,8 @@ public class TikaWithoutSchedulingTests {
         jobLauncher.launchJob();
 
         try {
-            Thread.sleep(20000);
-        } catch (InterruptedException e) {
+            testUtils.waitForEsReady(30000);
+        } catch (RuntimeException e) {
             e.printStackTrace();
         }
         assertEquals(1000,testUtils.countOutputDocsInES());

--- a/src/integration-test/resources/simple-compose-yaml/docker-compose.yml
+++ b/src/integration-test/resources/simple-compose-yaml/docker-compose.yml
@@ -7,14 +7,14 @@ services:
       - 5432:5432
     networks:
       - esnet
-  kibana:
-    image: docker.elastic.co/kibana/kibana-oss:6.4.2
-    environment:
-        ELASTICSEARCH_URL: http://elasticsearch:9200
-    ports:
-      - 5601:5601
-    networks:
-      - esnet
+#  kibana:
+#    image: docker.elastic.co/kibana/kibana-oss:6.4.2
+#    environment:
+#        ELASTICSEARCH_URL: http://elasticsearch:9200
+#    ports:
+#      - 5601:5601
+#    networks:
+#      - esnet
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.4.2
     environment:

--- a/test/examples/examples_common.py
+++ b/test/examples/examples_common.py
@@ -47,7 +47,7 @@ class TestSingleExample(unittest.TestCase):
         self.docker_cmd_down = 'docker-compose down -v'  # --volumes
 
         # set up logger
-        log_format = '[%(asctime)s] %(name)s: %(message)s'
+        log_format = '[%(asctime)s] [%(levelname)s] %(name)s: %(message)s'
         logging.basicConfig(format=log_format, level=logging.INFO)
         self.log = logging.getLogger(self.__class__.__name__)
 

--- a/test/examples/examples_common.py
+++ b/test/examples/examples_common.py
@@ -241,7 +241,7 @@ class TestSingleExampleDb2Es(TestSingleExample):
     """
     def __init__(self, source_conn_conf, source_table_name, es_conn_conf, es_index_name,
                  wait_for_source_ready_s=10,
-                 wait_for_sink_ready_max_s=300,
+                 wait_for_sink_ready_max_s=600,
                  *args, **kwargs):
         """
         :param source_conn_conf: the source JDBC connector configuration :class:~JdbcConnectorConfig
@@ -290,7 +290,7 @@ class TestSingleExampleDb2Db(TestSingleExample):
     """
     def __init__(self, source_conn_conf, source_table_name, sink_conn_conf, sink_table_name,
                  wait_for_source_ready_s=10,
-                 wait_for_sink_ready_max_s=300,
+                 wait_for_sink_ready_max_s=600,
                  *args, **kwargs):
         """
         :param source_conn_conf: the source JDBC connector configuration :class:~JdbcConnectorConfig

--- a/test/examples/examples_tests.py
+++ b/test/examples/examples_tests.py
@@ -76,8 +76,9 @@ class TestExample3(TestSingleExampleDb2Es):
         es_conn = ElasticConnector(self.es_conn_conf)
 
         self.log.info("Waiting for cogstack pipeline to process records ...")
-        time.sleep(self.wait_for_sink_ready_s)
-        recs_in = self.getRecordsCountFromSourceDb(source_conn_mt.connector, self.source_table_name_mt)
+        #time.sleep(self.wait_for_sink_ready_s)
+        self.waitForTargetEsReady(es_conn.connector, self.es_index_name, self.wait_for_sink_ready_max_s)
+        recs_in = self.getRecordsCountFromTargetDb(source_conn_mt.connector, self.source_table_name_mt)
         recs_out = self.getRecordsCountFromTargetEs(es_conn.connector, self.es_index_name_mt)
 
         self.assertEqual(recs_out, recs_in,
@@ -97,7 +98,6 @@ class TestExample4(TestSingleExampleDb2Es):
                                            es_index_name='sample_observations_view',
                                            example_path=os.path.join(examples_path, "example4"),
                                            sub_case='docx',
-                                           wait_for_sink_ready_s=120,
                                            *args, **kwargs)
 
 
@@ -114,7 +114,6 @@ class TestExample5s1(TestSingleExampleDb2Db):
                                              sink_table_name='medical_reports_processed',
                                              example_path=os.path.join(examples_path, "example5"),
                                              sub_case='docx',
-                                             wait_for_sink_ready_s=120,
                                              *args, **kwargs)
 
 
@@ -182,7 +181,6 @@ class TestExample8(TestSingleExampleDb2Es):
                                            es_conn_conf=DEFAULT_ES_CONFIG,
                                            es_index_name='sample_observations_view',
                                            example_path=os.path.join(examples_path, "example8"),
-                                           wait_for_sink_ready_s=240,
                                            image_build_rel_dir="../../../dockerfiles/gate",
                                            *args, **kwargs)
 
@@ -200,6 +198,5 @@ class TestExample9(TestSingleExampleDb2Es):
                                            es_conn_conf=DEFAULT_ES_CONFIG,
                                            es_index_name='sample_observations_view',
                                            example_path=os.path.join(examples_path, "example9"),
-                                           wait_for_sink_ready_s=240,
                                            image_build_rel_dir="../../../dockerfiles/gate",
                                            *args, **kwargs)

--- a/travis_gradle_build.sh
+++ b/travis_gradle_build.sh
@@ -6,7 +6,7 @@ export PING_SLEEP=30s
 export WORKDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export BUILD_OUTPUT=$WORKDIR/build.out
 
-DUMP_LINES=500
+DUMP_LINES=2000
 
 touch $BUILD_OUTPUT
 


### PR DESCRIPTION
Last fix for the very occasional tests timeout (both integration tests and examples) resulting in failed builds. Now awaiting until ES/DB sink is ready to query. Corresponds to PR #63 and #68 and possibly solves this issue.